### PR TITLE
Track model evaluation results in the model tracker

### DIFF
--- a/src/taoverse/model/data.py
+++ b/src/taoverse/model/data.py
@@ -49,7 +49,9 @@ class ModelId:
         return f"{self.namespace}:{self.name}:{self.commit}:{self.secure_hash}:{self.competition_id}"
 
     @classmethod
-    def from_compressed_str(cls, cs: str, default_competition_id: int = 0) -> Type["ModelId"]:
+    def from_compressed_str(
+        cls, cs: str, default_competition_id: int = 0
+    ) -> Type["ModelId"]:
         """Returns an instance of this class from a compressed string representation"""
         tokens = cs.split(":")
 
@@ -66,7 +68,7 @@ class ModelId:
             namespace=tokens[0],
             name=tokens[1],
             commit=tokens[2] if tokens[2] != "None" else None,
-            hash = hash,
+            hash=hash,
             secure_hash=tokens[3] if tokens[3] != "None" else None,
             competition_id=competition_id,
         )
@@ -93,3 +95,23 @@ class ModelMetadata:
 
     # Block on which this model was uploaded on the chain.
     block: int
+
+
+@dataclasses.dataclass
+class EvalResult:
+    """Records an evaluation result for a model."""
+
+    # The block the model was evaluated at.
+    block: int
+
+    # The average loss of this model when it was evaluated. May be math.inf if the model failed to evaluate.
+    avg_loss: float
+
+    # The block the winning model was submitted.
+    # Useful for computing when/if this model should be re-evaluated given a new epsilon.
+    winning_model_block: int
+
+    # The average loss of the winning model when this model was evaluated.
+    # If this was the winning model, equal to avg_loss.
+    # May be math.inf if the model failed to evaluate.
+    winning_model_loss: float

--- a/src/taoverse/model/model_tracker.py
+++ b/src/taoverse/model/model_tracker.py
@@ -1,24 +1,31 @@
 import copy
 import pickle
 import threading
-from typing import Dict, Optional, Set
+from collections import defaultdict
+from typing import Dict, List, Optional, Set
 
 import bittensor as bt
 
-from taoverse.model.data import ModelMetadata
+from taoverse.model.data import EvalResult, ModelMetadata
 
 
 class ModelTracker:
-    """Tracks the current model for each miner.
+    """Tracks model information for each miner.
 
     Thread safe.
     """
 
+    _MAX_EVAL_HISTORY_LEN = 3
+
     def __init__(
         self,
+        max_eval_history_len: int = _MAX_EVAL_HISTORY_LEN,
     ):
+        self.max_eval_history_len = max_eval_history_len
+
         # Create a dict from miner hotkey to model metadata.
         self.miner_hotkey_to_model_metadata_dict = dict()
+        self.miner_hotkey_to_eval_results = defaultdict(list)
 
         # Make this class thread safe because it will be accessed by multiple threads.
         # One for the downloading new models loop and one for the validating models loop.
@@ -30,14 +37,23 @@ class ModelTracker:
         # Open a writable binary file for pickle.
         with self.lock:
             with open(filepath, "wb") as f:
-                pickle.dump(self.miner_hotkey_to_model_metadata_dict, f)
+                pickle.dump(
+                    [
+                        self.miner_hotkey_to_model_metadata_dict,
+                        self.miner_hotkey_to_eval_results,
+                    ],
+                    f,
+                )
 
     def load_state(self, filepath):
         """Load the state from the provided filepath."""
 
         # Open a readable binary file for pickle.
         with open(filepath, "rb") as f:
-            self.miner_hotkey_to_model_metadata_dict = pickle.load(f)
+            (
+                self.miner_hotkey_to_model_metadata_dict,
+                self.miner_hotkey_to_eval_results,
+            ) = pickle.load(f)
 
     def get_miner_hotkey_to_model_metadata_dict(self) -> Dict[str, ModelMetadata]:
         """Returns the mapping from miner hotkey to model metadata."""
@@ -56,6 +72,12 @@ class ModelTracker:
                 return self.miner_hotkey_to_model_metadata_dict[hotkey]
             return None
 
+    def get_eval_results_for_miner_hotkey(self, hotkey: str) -> List[EvalResult]:
+        """Returns the latest evaluation results for a miner, ordered by block of eval (oldest first)."""
+
+        with self.lock:
+            return copy.deepcopy(self.miner_hotkey_to_eval_results[hotkey])
+
     def on_hotkeys_updated(self, incoming_hotkeys: Set[str]):
         """Notifies the tracker which hotkeys are currently being tracked on the metagraph."""
 
@@ -63,6 +85,7 @@ class ModelTracker:
             existing_hotkeys = set(self.miner_hotkey_to_model_metadata_dict.keys())
             for hotkey in existing_hotkeys - incoming_hotkeys:
                 del self.miner_hotkey_to_model_metadata_dict[hotkey]
+                del self.miner_hotkey_to_eval_results[hotkey]
                 bt.logging.trace(f"Removed outdated hotkey: {hotkey} from ModelTracker")
 
     def on_miner_model_updated(
@@ -77,6 +100,29 @@ class ModelTracker:
             model_metadata (ModelMetadata): The latest model metadata of the miner.
         """
         with self.lock:
+            prev_metadata = self.miner_hotkey_to_model_metadata_dict.get(hotkey, None)
             self.miner_hotkey_to_model_metadata_dict[hotkey] = model_metadata
 
+            # If the model was updated, clear the evaluation results since they're no
+            # longer relevant.
+            if prev_metadata != model_metadata:
+                self.miner_hotkey_to_eval_results[hotkey].clear()
+
             bt.logging.trace(f"Updated Miner {hotkey}. ModelMetadata={model_metadata}.")
+
+    def on_model_evaluated(self, hotkey: str, result: EvalResult) -> None:
+        """Notifies the tracker that a model has been evaluated.
+
+        Args:
+            hotkey (str): The miner's hotkey.
+            result (EvalResult): The evaluation result.
+        """
+        with self.lock:
+            eval_results = self.miner_hotkey_to_eval_results[hotkey]
+            eval_results.append(result)
+            if len(eval_results) > self.max_eval_history_len:
+                eval_results.pop(0)
+
+            eval_results.sort(key=lambda x: x.block)
+
+            bt.logging.trace(f"Updated eval results {hotkey}. EvalResult={result}.")


### PR DESCRIPTION
This change adds support to the model tracker to record model evaluation results. The intent is this information can then be used to smartly choose which models need reevaluated when a dynamic epsilon is used.

NOTE: This change is **not backwards compatible** and will require clearing the previously saved model tracker state. Any changes to our model_tracker class or the state it saves requires us to start over. 