### PR TITLE
Make max model file size a parameter of ModelConstraints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "taoverse"
-version = "1.0.3"
+version = "1.0.4"
 authors = [
   { name="Taoverse" },
 ]

--- a/src/taoverse/model/competition/data.py
+++ b/src/taoverse/model/competition/data.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Any, List, Type, Optional
+from typing import Any, List, Optional, Type
 
 from transformers import PreTrainedModel
 
@@ -36,6 +36,9 @@ class ModelConstraints:
 
     # The function to compute epsilon as a function of the model's submitted block and the current block.
     epsilon_func: EpsilonFunc = field(compare=False)
+    
+    # The maximum size (in bytes) the model is allowed to be.
+    max_bytes: int
 
     # Any additional arguments to pass to from_pretrained
     kwargs: Any = field(default_factory=dict)
@@ -45,7 +48,6 @@ class ModelConstraints:
 
     # Norm validation values.
     norm_validation_constraints: Optional[NormValidationConstraints] = None
-
 
 @dataclass
 class Competition:

--- a/src/taoverse/model/model_updater.py
+++ b/src/taoverse/model/model_updater.py
@@ -1,11 +1,11 @@
 import statistics
-from typing import List, Optional, Tuple, Dict
+from typing import Dict, List, Optional, Tuple
 
 import bittensor as bt
 
 from taoverse.model.competition import utils as competition_utils
 from taoverse.model.competition.data import Competition, ModelConstraints
-from taoverse.model.data import Model, ModelMetadata, ModelId
+from taoverse.model.data import Model, ModelMetadata
 from taoverse.model.model_tracker import ModelTracker
 from taoverse.model.storage.local_model_store import LocalModelStore
 from taoverse.model.storage.model_metadata_store import ModelMetadataStore
@@ -47,16 +47,20 @@ class ModelUpdater:
         # Check that the parameter count of the model is within allowed bounds.
         parameter_size = sum(p.numel() for p in model.pt_model.parameters())
 
-
-
         if (
-                parameter_size > model_constraints.max_model_parameter_size
-                or parameter_size < model_constraints.min_model_parameter_size
+            parameter_size > model_constraints.max_model_parameter_size
+            or parameter_size < model_constraints.min_model_parameter_size
         ):
-            bt.logging.debug(f'Model {model.id.name} does not satisfy constraints for competition {model.id.competition_id}')
-            bt.logging.debug(f'Number of model parameters is {parameter_size}')
-            bt.logging.debug(f'Max parameters allowed is {model_constraints.max_model_parameter_size}')
-            bt.logging.debug(f'Min parameters allowed is {model_constraints.min_model_parameter_size}')
+            bt.logging.debug(
+                f"Model {model.id.name} does not satisfy constraints for competition {model.id.competition_id}"
+            )
+            bt.logging.debug(f"Number of model parameters is {parameter_size}")
+            bt.logging.debug(
+                f"Max parameters allowed is {model_constraints.max_model_parameter_size}"
+            )
+            bt.logging.debug(
+                f"Min parameters allowed is {model_constraints.min_model_parameter_size}"
+            )
             return False
 
         # Make sure it's an allowed architecture.
@@ -145,7 +149,7 @@ class ModelUpdater:
         # Check that the hash of the downloaded content matches.
         # This is only useful for SN9's legacy competition before multi-competition support
         # was introduced. Securing hashes was optional. In modern competitions, `hash` is
-        # always None, and only `secure_hash` is used.  
+        # always None, and only `secure_hash` is used.
         if model.id.hash != metadata.id.hash:
             # Check that the hash of the downloaded content matches.
             secure_hash = get_hash_of_two_strings(model.id.hash, hotkey)

--- a/src/taoverse/model/storage/remote_model_store.py
+++ b/src/taoverse/model/storage/remote_model_store.py
@@ -1,6 +1,6 @@
 import abc
 
-from taoverse.model.competition.data import Competition
+from taoverse.model.competition.data import ModelConstraints
 from taoverse.model.data import Model, ModelId
 
 
@@ -8,13 +8,18 @@ class RemoteModelStore(abc.ABC):
     """An abstract base class for storing and retrieving a pre trained model."""
 
     @abc.abstractmethod
-    async def upload_model(self, model: Model, competition: Competition) -> ModelId:
+    async def upload_model(
+        self, model: Model, model_constraints: ModelConstraints
+    ) -> ModelId:
         """Uploads a trained model in the appropriate location based on implementation."""
         pass
 
     @abc.abstractmethod
     async def download_model(
-        self, model_id: ModelId, local_path: str, competition: Competition
+        self,
+        model_id: ModelId,
+        local_path: str,
+        model_constraints: ModelConstraints,
     ) -> Model:
         """Retrieves a trained model from the appropriate location and stores at the given path."""
         pass

--- a/tests/model/competition/test_competition_utils.py
+++ b/tests/model/competition/test_competition_utils.py
@@ -53,6 +53,7 @@ class TestCompetitionUtils(unittest.TestCase):
                 norm_eps_hard=1000,
             ),
             epsilon_func=FixedEpsilon(0.005),
+            max_bytes=15*1024*1024*1024,  # 15 GB
         ),
     }
 
@@ -95,6 +96,7 @@ class TestCompetitionUtils(unittest.TestCase):
                     norm_eps_hard=1000,
                 ),
                 epsilon_func=FixedEpsilon(0.005),
+                max_bytes=15*1024*1024*1024,  # 15 GB
             ),
             reward_percentage=1.0,
         )
@@ -147,6 +149,7 @@ class TestCompetitionUtils(unittest.TestCase):
                         norm_eps_hard=1000,
                     ),
                     epsilon_func=FixedEpsilon(0.005),
+                    max_bytes=15*1024*1024*1024,  # 15 GB
                 ),
                 reward_percentage=1.0,
             ),

--- a/tests/model/storage/fake_remote_model_store.py
+++ b/tests/model/storage/fake_remote_model_store.py
@@ -1,7 +1,7 @@
 import uuid
 from dataclasses import replace
 
-from taoverse.model.competition.data import Competition
+from taoverse.model.competition.data import ModelConstraints
 from taoverse.model.data import Model, ModelId
 from taoverse.model.storage.disk import utils
 from taoverse.model.storage.remote_model_store import RemoteModelStore
@@ -13,7 +13,9 @@ class FakeRemoteModelStore(RemoteModelStore):
     def __init__(self):
         self.remote_models = dict()
 
-    async def upload_model(self, model: Model, competition: Competition) -> ModelId:
+    async def upload_model(
+        self, model: Model, model_constraints: ModelConstraints
+    ) -> ModelId:
         """Fake uploads a model."""
 
         model_id = model.id
@@ -33,7 +35,7 @@ class FakeRemoteModelStore(RemoteModelStore):
         return model_id
 
     async def download_model(
-        self, model_id: ModelId, local_path: str, competition: Competition
+        self, model_id: ModelId, local_path: str, model_constraints: ModelConstraints
     ) -> Model:
         """Retrieves a trained model from memory."""
 

--- a/tests/model/test_model_updater.py
+++ b/tests/model/test_model_updater.py
@@ -58,6 +58,7 @@ class TestModelUpdater(unittest.TestCase):
                 norm_eps_hard=1000,
             ),
             epsilon_func=FixedEpsilon(0.005),
+            max_bytes=15*1024*1024*1024,  # 15 GB
         ),
     }
 


### PR DESCRIPTION
Currently, we have a hardcoded value for the maximum model size, which isn't accessible to the package user.

This change adds the max model size as a field on the ModelConstraints, allowing for per-competition model size limits.

This also makes sure that invalid models detected during download throw a MinerMisconfiguredError, which is used to mark failed evaluations in SN9.

Also includes 1 unrelated formatting fix on the model_updater.py