### PR TITLE
Add EvalTask

### DIFF
--- a/src/taoverse/model/competition/data.py
+++ b/src/taoverse/model/competition/data.py
@@ -5,7 +5,7 @@ from typing import Any, List, Optional, Type
 from transformers import PreTrainedModel
 
 from taoverse.model.competition.epsilon import EpsilonFunc
-from taoverse.model.competition.eval import EvalTask
+from taoverse.model.eval.task import EvalTask
 
 
 @dataclass

--- a/src/taoverse/model/competition/data.py
+++ b/src/taoverse/model/competition/data.py
@@ -1,9 +1,11 @@
 from dataclasses import dataclass, field
+import dataclasses
 from typing import Any, List, Optional, Type
 
 from transformers import PreTrainedModel
 
 from taoverse.model.competition.epsilon import EpsilonFunc
+from taoverse.model.competition.eval import EvalTask
 
 
 @dataclass
@@ -36,7 +38,7 @@ class ModelConstraints:
 
     # The function to compute epsilon as a function of the model's submitted block and the current block.
     epsilon_func: EpsilonFunc = field(compare=False)
-    
+
     # The maximum size (in bytes) the model is allowed to be.
     max_bytes: int
 
@@ -48,6 +50,7 @@ class ModelConstraints:
 
     # Norm validation values.
     norm_validation_constraints: Optional[NormValidationConstraints] = None
+
 
 @dataclass
 class Competition:
@@ -62,3 +65,6 @@ class Competition:
 
     # Percentage of emissions dedicated to this competition.
     reward_percentage: float
+
+    # The set of tasks used to evaluate models in this competition.
+    eval_tasks: List[EvalTask] = dataclasses.field(default_factory=list)

--- a/src/taoverse/model/competition/eval.py
+++ b/src/taoverse/model/competition/eval.py
@@ -12,15 +12,15 @@ class EvalTask:
     
     # The identifier of the dataset to evaluate on.
     dataset_id: int
-    
-    # Additional keyword arguments to pass to the dataset loader.
-    dataset_kwargs: dict = dataclasses.field(default_factory=dict)
 
     # The identifier of the normalization method to use.
     normalization_id: int
 
     # Additional keyword arguments to pass to the normalization method.
     normalization_kwargs: dict = dataclasses.field(default_factory=dict)
+    
+    # Additional keyword arguments to pass to the dataset loader.
+    dataset_kwargs: dict = dataclasses.field(default_factory=dict)
 
     # Weight to apply to the normalized score to provide relative weight against other EvalTasks.
     weight: float = 1.0

--- a/src/taoverse/model/competition/eval.py
+++ b/src/taoverse/model/competition/eval.py
@@ -1,0 +1,30 @@
+import dataclasses
+
+@dataclasses.dataclass
+class EvalTask:
+    """Represents a task to evaluate a model on."""
+
+    # Friendly name for the task.
+    name: str
+
+    # The identifier of the evaluation method to use.
+    method_id: int
+    
+    # The identifier of the dataset to evaluate on.
+    dataset_id: int
+    
+    # Additional keyword arguments to pass to the dataset loader.
+    dataset_kwargs: dict = dataclasses.field(default_factory=dict)
+
+    # The identifier of the normalization method to use.
+    normalization_id: int
+
+    # Additional keyword arguments to pass to the normalization method.
+    normalization_kwargs: dict = dataclasses.field(default_factory=dict)
+
+    # Weight to apply to the normalized score to provide relative weight against other EvalTasks.
+    weight: float = 1.0
+
+    def __post_init__(self):
+        if self.weight <= 0:
+            raise ValueError("Weight must be positive.")

--- a/src/taoverse/model/eval/normalization.py
+++ b/src/taoverse/model/eval/normalization.py
@@ -1,0 +1,56 @@
+from enum import IntEnum
+import math
+
+
+class NormalizationId(IntEnum):
+    """Enumeration of normalization methods."""
+
+    # No normalization is applied and the raw score is used.
+    NONE = 0
+
+    # Normalizes between [0, 1] using an inverse exponential function.
+    INVERSE_EXPONENTIAL = 1
+
+
+def normalize_score(
+    score: float,
+    normalization_id: NormalizationId,
+    norm_kwargs: dict = {},
+) -> float:
+    """Normalizes a score based on the provided normalization method.
+
+    Args:
+        score (float): The raw score to normalize.
+        normalization_id (NormalizationId): The identifier of the normalization method to use.
+        norm_kwargs (dict): Keyword arguments to pass to the normalization method.
+
+    Returns:
+        float: The normalized score.
+    """
+    match normalization_id:
+        case NormalizationId.NONE:
+            return _normalize_none(score)
+        case NormalizationId.INVERSE_EXPONENTIAL:
+            return _normalize_inverse_exponential(score, **norm_kwargs)
+        case _:
+            raise ValueError(f"Unhandled normalization method {normalization_id}.")
+
+
+def _normalize_inverse_exponential(score: float, ceiling: float) -> float:
+    """Normalizes between [0, 1] using an inverse exponential function.
+
+    Args:
+        score (float): The raw score to normalize.
+        ceiling (float): The maximum desirable score. Everything above this will be clipped.
+
+    Returns:
+        float: The normalized score.
+    """
+    if score >= ceiling:
+        return 1.0
+
+    return (1 - math.exp(-score / ceiling)) / (1 - math.exp(-1))
+
+
+def _normalize_none(score: float) -> float:
+    return score

--- a/src/taoverse/model/eval/task.py
+++ b/src/taoverse/model/eval/task.py
@@ -1,5 +1,7 @@
 import dataclasses
 
+from taoverse.model.eval.normalization import NormalizationId
+
 @dataclasses.dataclass
 class EvalTask:
     """Represents a task to evaluate a model on."""
@@ -14,7 +16,7 @@ class EvalTask:
     dataset_id: int
 
     # The identifier of the normalization method to use.
-    normalization_id: int
+    normalization_id: NormalizationId = NormalizationId.NONE
 
     # Additional keyword arguments to pass to the normalization method.
     normalization_kwargs: dict = dataclasses.field(default_factory=dict)
@@ -28,3 +30,15 @@ class EvalTask:
     def __post_init__(self):
         if self.weight <= 0:
             raise ValueError("Weight must be positive.")
+
+        match self.normalization_id:
+            case NormalizationId.NONE:
+                if self.normalization_kwargs:
+                    raise ValueError(
+                        "Normalization kwargs should not be provided for NONE normalization."
+                    )
+            case NormalizationId.INVERSE_EXPONENTIAL:
+                if "ceiling" not in self.normalization_kwargs:
+                    raise ValueError(
+                        "Normalization kwargs must contain a 'ceiling' value."
+                    )

--- a/src/taoverse/utilities/utils.py
+++ b/src/taoverse/utilities/utils.py
@@ -1,10 +1,12 @@
 import concurrent
+import dataclasses
 from datetime import datetime, timedelta
 import functools
+import hashlib
 import multiprocessing
 import os
 import random
-from typing import Any, Optional
+from typing import Any, Optional, Sequence
 
 import bittensor as bt
 
@@ -123,3 +125,13 @@ def random_date(start: datetime, end: datetime, seed: int = None) -> datetime:
 
     # Add the random seconds to the start time
     return start + timedelta(seconds=random_seconds)
+
+def fingerprint(any: "Sequence[DataclassInstance] | DataclassInstance") -> int:
+    """Returns a fingerprint for a Dataclass or sequence of Dataclasses."""
+    
+    # Convert the dataclass to a string representation of the values
+    if isinstance(any, Sequence):
+        data_string = str([dataclasses.asdict(x) for x in any]).encode('utf-8')
+    else:
+        data_string = str(dataclasses.asdict(any)).encode('utf-8')
+    return hashlib.sha256(data_string).hexdigest()

--- a/tests/model/eval/test_normalization.py
+++ b/tests/model/eval/test_normalization.py
@@ -1,0 +1,47 @@
+import random
+import unittest
+
+from taoverse.model.eval.normalization import NormalizationId, normalize_score
+
+
+class TestNormalizeScore(unittest.TestCase):
+
+    def test_normalize_none(self):
+        for _ in range(10):
+            score = random.random()
+            normalization_id = NormalizationId.NONE
+            normalized_score = normalize_score(score, normalization_id)
+            self.assertEqual(normalized_score, score)
+
+    def test_normalize_inverse_exponential(self):
+        score = 5.0
+        normalization_id = NormalizationId.INVERSE_EXPONENTIAL
+        norm_kwargs = {"ceiling": 10.0}
+        normalized_score = normalize_score(score, normalization_id, norm_kwargs)
+        self.assertAlmostEqual(normalized_score, 0.6224593312018546, places=6)
+
+    def test_normalize_inverse_exponential_above_ceiling(self):
+        score = 15.0
+        normalization_id = NormalizationId.INVERSE_EXPONENTIAL
+        norm_kwargs = {"ceiling": 10.0}
+        normalized_score = normalize_score(score, normalization_id, norm_kwargs)
+        self.assertEqual(normalized_score, 1.0)
+
+    def test_normalize_inverse_exponential_always_between_0_and_1(self):
+        for i in range(101):
+            score = i / 10
+            normalization_id = NormalizationId.INVERSE_EXPONENTIAL
+            norm_kwargs = {"ceiling": 10.0}
+            normalized_score = normalize_score(score, normalization_id, norm_kwargs)
+            self.assertTrue(0 <= normalized_score <= 1)
+
+    def test_unhandled_normalization_method(self):
+        score = 5.0
+        normalization_id = 999  # Invalid normalization method
+        norm_kwargs = {}
+        with self.assertRaises(ValueError):
+            normalize_score(score, normalization_id, norm_kwargs)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/model/eval/test_task.py
+++ b/tests/model/eval/test_task.py
@@ -1,0 +1,53 @@
+import unittest
+
+from taoverse.model.eval.normalization import NormalizationId
+from taoverse.model.eval.task import EvalTask
+
+
+class TestEvalTask(unittest.TestCase):
+
+    def test_eval_task_initialization(self):
+        task = EvalTask(
+            name="Test Task",
+            dataset_id=1,
+            method_id=1,
+            normalization_id=NormalizationId.NONE,
+        )
+        self.assertEqual(task.name, "Test Task")
+        self.assertEqual(task.dataset_id, 1)
+        self.assertEqual(task.method_id, 1)
+        self.assertEqual(task.normalization_id, NormalizationId.NONE)
+        self.assertEqual(task.weight, 1.0)
+
+    def test_eval_task_weight_validation(self):
+        with self.assertRaises(ValueError):
+            EvalTask(
+                name="Test Task",
+                dataset_id=1,
+                method_id=2,
+                normalization_id=NormalizationId.NONE,
+                weight=0,
+            )
+
+    def test_eval_task_normalization_kwargs_validation_none(self):
+        with self.assertRaises(ValueError):
+            EvalTask(
+                name="Test Task",
+                dataset_id=1,
+                method_id=1,
+                normalization_id=NormalizationId.NONE,
+                normalization_kwargs={"some_key": "some_value"},
+            )
+
+    def test_eval_task_normalization_kwargs_validation_inverse_exponential(self):
+        with self.assertRaises(ValueError):
+            EvalTask(
+                name="Test Task",
+                dataset_id=1,
+                method_id=2,
+                normalization_id=NormalizationId.INVERSE_EXPONENTIAL,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/utilities/test_utils.py
+++ b/tests/utilities/test_utils.py
@@ -1,10 +1,22 @@
+import dataclasses
 import functools
 import time
 import unittest
 from tempfile import NamedTemporaryFile
 
+from numpy import str_
+
 from taoverse.utilities import utils
 from taoverse.utilities.utils import run_in_subprocess, run_in_thread
+
+
+@dataclasses.dataclass
+class SimpleObject:
+    int_field: int
+    bool_field: bool
+    str_field: str
+    list_field: list
+    dict_field: dict
 
 
 class TestUtils(unittest.TestCase):
@@ -107,6 +119,23 @@ class TestUtils(unittest.TestCase):
 
             utils.save_version(f.name, version)
             self.assertEqual(utils.get_version(f.name), version)
+
+    def test_fingerprint_single_object(self):
+        a = SimpleObject(1, True, "hello", [1, 2, 3], {"a": 1, "b": 2})
+        self.assertEqual(utils.fingerprint(a), utils.fingerprint(a))
+
+        b = SimpleObject(1, True, "other", [1, 2, 3], {"a": 1, "b": 2})
+        self.assertNotEqual(utils.fingerprint(a), utils.fingerprint(b))
+
+    def test_fingerprint_multiple_objects(self):
+        a = SimpleObject(1, True, "hello", [1, 2, 3], {"a": 1, "b": 2})
+        b = SimpleObject(1, True, "other", [1, 2, 3], {"a": 1, "b": 2})
+
+        self.assertEqual(utils.fingerprint([a, b]), utils.fingerprint([a, b]))
+        self.assertEqual(utils.fingerprint([a]), utils.fingerprint([a]))
+
+        self.assertNotEqual(utils.fingerprint([a]), utils.fingerprint([b]))
+        self.assertNotEqual(utils.fingerprint([a, b]), utils.fingerprint([b, a]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This change moves the EvalTask into taoverse and adds it to the competition definition. This will allow us to define evaluation tasks in the competition schedule and schedule in changes to the evaluation tasks at future blocks.

In addition, a fingerprint method is added so that we can easily determine when the evaluation tasks change for a competition. This information can then be used to clear the EvalResults for a particular competition from the model tracker (in a separate PR), which will allow all models in that competition to be retried on the new EvalTasks.