### PR TITLE
Add method to clear eval results from the model tracker

### DIFF
--- a/src/taoverse/model/model_tracker.py
+++ b/src/taoverse/model/model_tracker.py
@@ -80,6 +80,14 @@ class ModelTracker:
         with self.lock:
             return copy.deepcopy(self.miner_hotkey_to_eval_results[hotkey].get(competition_id, []))
         
+    def clear_eval_results(self, competition_id: int) -> None:
+        """Clears all evaluation results for a given competition id."""
+        
+        with self.lock:
+            for eval_results in self.miner_hotkey_to_eval_results.values():
+                if competition_id in eval_results:
+                    del eval_results[competition_id]
+        
     def get_block_last_evaluated(self, hotkey: str) -> Optional[int]:
         """Returns the block of the most recent evaluation for a miner, across all competitions.
         

--- a/tests/model/test_model_tracker.py
+++ b/tests/model/test_model_tracker.py
@@ -319,6 +319,46 @@ class TestModelTracker(unittest.TestCase):
         )
         self.assertEqual(self.model_tracker.get_block_last_evaluated(hotkey), 5)
 
+    def test_clear_eval_results_missing_comp(self):
+        """Verifies that clear_eval_results doesn't crash when the competition doesn't exist."""
+        
+        eval_result1 = EvalResult(
+            block=1, score=1, winning_model_block=1, winning_model_score=2
+        )
+        eval_result2 = EvalResult(
+            block=2, score=2, winning_model_block=1, winning_model_score=2
+        )
+        self.model_tracker.on_model_evaluated("miner", 1, eval_result1)
+        self.model_tracker.on_model_evaluated("miner", 1, eval_result2)
+
+        self.model_tracker.clear_eval_results(2)
+
+        self.assertEqual(
+            self.model_tracker.get_eval_results_for_miner_hotkey("miner", 1),
+            [eval_result1, eval_result2],
+        )
+
+    def test_clear_eval_results(self):
+        """Verifies that clear_eval_results only deletes results from the right competition."""
+
+        eval_result1 = EvalResult(
+            block=1, score=1, winning_model_block=1, winning_model_score=2
+        )
+        eval_result2 = EvalResult(
+            block=2, score=2, winning_model_block=1, winning_model_score=2
+        )
+        self.model_tracker.on_model_evaluated("miner", 1, eval_result1)
+        self.model_tracker.on_model_evaluated("miner", 1, eval_result1)
+        self.model_tracker.on_model_evaluated("miner", 2, eval_result2)
+
+        self.assertEqual(
+            self.model_tracker.get_eval_results_for_miner_hotkey("miner", 1),
+            [eval_result1, eval_result1],
+        )
+        self.model_tracker.clear_eval_results(1)
+        self.assertEqual(
+            self.model_tracker.get_eval_results_for_miner_hotkey("miner", 1), []
+        )
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The purpose of this method is to allow us to ensure models are retried in a competition if the eval task set changes.