### PR TITLE
Release 1.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "taoverse"
-version = "1.0.10"
+version = "1.1.0"
 authors = [
   { name="Taoverse" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "taoverse"
-version = "1.1.0"
+version = "1.1.1"
 authors = [
   { name="Taoverse" },
 ]

--- a/src/taoverse/model/competition/competition_tracker.py
+++ b/src/taoverse/model/competition/competition_tracker.py
@@ -2,6 +2,7 @@ import typing
 
 import bittensor as bt
 import torch
+
 from taoverse.model.competition.data import Competition
 
 
@@ -127,7 +128,6 @@ class CompetitionTracker:
             {
                 "weights_by_competition": self.weights_by_competition,
                 "num_neurons": self.num_neurons,
-                "alpha": self.alpha,
             },
             filepath,
         )
@@ -137,4 +137,3 @@ class CompetitionTracker:
         state = torch.load(filepath)
         self.weights_by_competition = state["weights_by_competition"]
         self.num_neurons = state["num_neurons"]
-        self.alpha = state["alpha"]


### PR DESCRIPTION
Notes:
- This release's schema is incompatible with 1.1.0

Fixes:
- Doesn't save/load the competition tracker alpha to file.

